### PR TITLE
correct gem location in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ gem install capistrano-composer
 Or if you're using Bundler, add it to your `Gemfile`:
 
 ```ruby
-gem 'capistrano-composer', github: 'swalkinshaw/composer'
+gem 'capistrano-composer', github: 'roots/capistrano-composer'
 ```
 
 2. Add to `Capfile` or `config/deploy.rb`:


### PR DESCRIPTION
gem 'capistrano-composer', github: 'swalkinshaw/composer' doesn't work - Repository not found.
