### PR TITLE
Incorrect arg order for composer install command

### DIFF
--- a/lib/capistrano/tasks/composer.cap
+++ b/lib/capistrano/tasks/composer.cap
@@ -11,7 +11,9 @@ namespace :composer do
   task :install do
     on roles fetch(:composer_roles) do
       within release_path do
-        execute :composer, fetch(:composer_flags), :install
+        with fetch(:composer_env) do
+          execute :composer, fetch(:composer_flags), :install
+        end
       end
     end
   end
@@ -23,5 +25,6 @@ namespace :load do
   task :defaults do
     set :composer_flags, '--no-dev --no-scripts --quiet --optimize-autoloader'
     set :composer_roles, :all
+    set :composer_env, { }
   end
 end


### PR DESCRIPTION
Prior to this composer just dumped help message instead of actually installing dependencies.

I am currently working on updating capifony as well, I would like to use this gem, and we need the
ability to set environment variables for a composer run - so I have added that too!

Thanks
