### PR TITLE
Configurable environment variables for composer:install

### DIFF
--- a/lib/capistrano/tasks/composer.cap
+++ b/lib/capistrano/tasks/composer.cap
@@ -11,7 +11,9 @@ namespace :composer do
   task :install do
     on roles fetch(:composer_roles) do
       within release_path do
-        execute :composer, :install, fetch(:composer_flags)
+        with fetch(:composer_env) do
+          execute :composer, :install, fetch(:composer_flags)
+        end
       end
     end
   end
@@ -23,5 +25,6 @@ namespace :load do
   task :defaults do
     set :composer_flags, '--no-dev --no-scripts --quiet --optimize-autoloader'
     set :composer_roles, :all
+    set :composer_env, { }
   end
 end


### PR DESCRIPTION
(replaces #5)

I am working on rewriting [Capifony to v3](https://github.com/everzet/capifony/pull/437), and rather than rewriting composer logic there, it is better to use this gem.

We need to be able to set environment variables during the composer run therefore I have added that capability

Therefore a user can do something like 

``` ruby
set :composer_env, { symfony_env: 'prod' } 
```

Which would result in `SYMFONY_ENV=prod /usr/bin/env composer install` being run
