### PR TITLE
Copy previous releases vendors by default

### DIFF
--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -40,6 +40,21 @@ namespace :composer do
     invoke "composer:run", :install, fetch(:composer_install_flags)
   end
 
+  task :copy_from_previous_release do
+    next unless fetch(:composer_copy_previous_vendors)
+    on roles fetch(:composer_roles) do
+      last_release = capture(:ls, '-xr', releases_path).split.fetch(1, nil)
+      next unless last_release
+      last_release_path = releases_path.join(last_release)
+
+      if test "[ -d #{last_release_path.join('vendor')} ]"
+        within last_release_path do
+          execute :cp, "-R", "vendor", release_path.join('vendor')
+        end
+      end
+    end
+  end
+
   task :dump_autoload do
     invoke "composer:run", :dumpautoload, fetch(:composer_dump_autoload_flags)
   end
@@ -49,6 +64,7 @@ namespace :composer do
     invoke "composer:run", :selfupdate
   end
 
+  before 'deploy:updated', 'composer:copy_from_previous_release'
   before 'deploy:updated', 'composer:install'
 end
 
@@ -58,5 +74,6 @@ namespace :load do
     set :composer_roles, :all
     set :composer_dump_autoload_flags, '--optimize'
     set :composer_download_url, "https://getcomposer.org/installer"
+    set :composer_copy_previous_vendors, true
   end
 end


### PR DESCRIPTION
I have added the option (shown with default value)

``` ruby
set :composer_copy_previous_vendors, true
```

Along with the task `composer:copy_from_previous_release` (the name sucks). It runs just before `composer:install` and if there is no change in dependencies between releases then it essentially makes `composer:install` a no-op, speeding things up somewhat (and saving on bandwidth, if there is no composer cache).
