### PR TITLE
Support composer.phar version specify

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ set :composer_install_flags, '--no-dev --no-scripts --quiet --optimize-autoloade
 set :composer_roles, :all
 set :composer_dump_autoload_flags, '--optimize'
 set :composer_download_url, "https://getcomposer.org/installer"
+set :composer_version, '1.0.0-alpha8' #(default: not set)
 ```
 
 ### Installing composer as part of a deployment

--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -12,7 +12,9 @@ namespace :composer do
     on roles fetch(:composer_roles) do
       within shared_path do
         unless test "[", "-e", "composer.phar", "]"
-          execute :curl, "-s", fetch(:composer_download_url), "|", :php
+          composer_version = fetch(:composer_version, nil)
+          composer_version_option = composer_version ? "-- --version=#{composer_version}" : ""
+          execute :curl, "-s", fetch(:composer_download_url), "|", :php, composer_version_option
         end
       end
     end
@@ -44,9 +46,15 @@ namespace :composer do
     invoke "composer:run", :dumpautoload, fetch(:composer_dump_autoload_flags)
   end
 
-  desc "Run the self-update command for composer.phar"
+  desc <<-DESC
+        Run the self-update command for composer.phar
+
+        You can update to a specific release by setting the variables shown below.
+
+          set :composer_version, '1.0.0-alpha8'
+    DESC
   task :self_update do
-    invoke "composer:run", :selfupdate
+    invoke "composer:run", :selfupdate, fetch(:composer_version, '')
   end
 
   before 'deploy:updated', 'composer:install'


### PR DESCRIPTION
Composer latest can update to a specific release by running the `self-update`.
(& getcomposer's `install`)

Hope to support that :)
#### References
- [Download Composer](https://getcomposer.org/download/)
- [Documentation 13. self-update](https://getcomposer.org/doc/03-cli.md#self-update)
