### PR TITLE
Properly pass extra arguments to composer

### DIFF
--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -20,7 +20,7 @@ namespace :composer do
     end
   end
 
-  task :run, :command do |t, args|
+  task :run, :command, :extras do |t, args|
     args.with_defaults(:command => :list)
     on roles fetch(:composer_roles) do
       within release_path do


### PR DESCRIPTION
I'm not a Rubyist, so I'm not a 100% sure if this is the way to do it.

I couldn't find any other place where `args.extras` could be defined, so I'm not sure how this would work at all previously. 

Composer would always be called without arguments, which would cause the
following error when running install:

```
The lock file does not contain require-dev information, run install
with the --no-dev option or run update to install those packages.
```
