### PR TITLE
Make run  command working

### DIFF
--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -24,7 +24,7 @@ namespace :composer do
     args.with_defaults(:command => :list)
     on roles fetch(:composer_roles) do
       within release_path do
-        execute :composer, args[:command], *args.extras
+        execute :php, shared_path + 'composer.phar', args[:command], *args.extras
       end
     end
   end


### PR DESCRIPTION
The `install_executable` task installs composer inside the shared folder within the name of `composer.phar` which is a php packages without execute rights. So when `run` command runs it ends up with an error like `composer: command not found`. The problems are:
- composer.phar is the file name not composer. 
- since the file is not executable you can't execute it

This PR solves the file name and makes composer executed through php.
