### PR TITLE
Force rake depencency of > 10.1

### DIFF
--- a/capistrano-composer.gemspec
+++ b/capistrano-composer.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capistrano', '>= 3.0.0.pre'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 10.1'
 end


### PR DESCRIPTION
This library uses the `args.extras` feature of rake which is only
present in v10.1 and above. This has caused an issue for a user as
reported in GH issue #16
