### PR TITLE
Updated task description to install Composer after deploy:starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ deployment (composer.phar is install in the shared path).
 SSHKit.config.command_map[:composer] = "php #{shared_path.join("composer.phar")}"
 
 namespace :deploy do
-  before :starting, 'composer:install_executable'
+  after :starting, 'composer:install_executable'
 end
 ```
 

--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -3,9 +3,9 @@ namespace :composer do
     Installs composer.phar to the shared directory
     In order to use the .phar file, the composer command needs to be mapped:
       SSHKit.config.command_map[:composer] = "\#{shared_path.join("composer.phar")}"
-    This is best used before deploy:starting:
+    This is best used after deploy:starting:
       namespace :deploy do
-        before :starting, 'composer:install_executable'
+        after :starting, 'composer:install_executable'
       end
   DESC
   task :install_executable do


### PR DESCRIPTION
This fixes the first install when directories does not exist.

To be consistent with install path (shared folder), `composer:install_executable` task cannot be called before `deploy:check:directories` (so `deploy:starting`) which creates directories if necessary.
