### PR TITLE
Added new task to copy vendor from previous release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,19 @@ Require the module in your `Capfile`:
 require 'capistrano/composer'
 ```
 
-`capistrano/composer` comes with 5 tasks:
+`capistrano/composer` comes with 6 tasks:
 
 * composer:install
 * composer:install_executable
+* composer:copy_vendors
 * composer:dump_autoload
 * composer:self_update
 * composer:run
 
-The `composer:install` task will run before deploy:updated as part of
+The `composer:copy_vendors` task will run before `composer:install` in order to
+copy vendor directory from previous release. This allows to speed up a deploy.
+
+The `composer:install` task will run before `deploy:updated` as part of
 Capistrano's default deploy, or can be run in isolation with:
 
 ```bash

--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -20,6 +20,20 @@ namespace :composer do
     end
   end
 
+  desc <<-DESC
+        Speeds up the time of a deploy by copying
+        vendor directory from previous release.
+    DESC
+  task :copy_vendors do
+    on release_roles(fetch(:composer_roles)) do
+      vendor_path = current_path.join('vendor')
+
+      if test "[ -d #{vendor_path} ] || [ -h #{vendor_path} ]"
+        execute :cp, '-a', vendor_path, release_path.join('vendor')
+      end
+    end
+  end
+
   task :run, :command do |t, args|
     args.with_defaults(:command => :list)
     on release_roles(fetch(:composer_roles)) do
@@ -56,6 +70,8 @@ namespace :composer do
   task :self_update do
     invoke "composer:run", :selfupdate, fetch(:composer_version, '')
   end
+
+  before :install, :copy_vendors
 
   before 'deploy:updated', 'composer:install'
 end


### PR DESCRIPTION
This new task will run before `composer:install` in order to copy vendor directory from previous release. This allows to speed up a deploy.
