### PR TITLE
Composer working dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Configurable options, shown here with defaults:
 ```ruby
 set :composer_install_flags, '--no-dev --no-interaction --quiet --optimize-autoloader'
 set :composer_roles, :all
+set :composer_working_dir, -> { fetch(:release_path) }
 set :composer_dump_autoload_flags, '--optimize'
 set :composer_download_url, "https://getcomposer.org/installer"
 set :composer_version, '1.0.0-alpha8' #(default: not set)

--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -23,7 +23,7 @@ namespace :composer do
   task :run, :command do |t, args|
     args.with_defaults(:command => :list)
     on release_roles(fetch(:composer_roles)) do
-      within release_path do
+      within fetch(:composer_working_dir) do
         execute :composer, args[:command], *args.extras
       end
     end
@@ -64,6 +64,7 @@ namespace :load do
   task :defaults do
     set :composer_install_flags, '--no-dev --prefer-dist --no-interaction --quiet --optimize-autoloader'
     set :composer_roles, :all
+    set :composer_working_dir, -> { fetch(:release_path) }
     set :composer_dump_autoload_flags, '--optimize'
     set :composer_download_url, "https://getcomposer.org/installer"
   end


### PR DESCRIPTION
Hi!

In our deployment setup we need to change the _working_dir_ in which composer is running on. Normally this is done by the `--working-dir` argument but I think it is better to change that within the `within()` function of the :run  task.
So I made a separate configuration-value to change the working dir. Default is set to the current `release_path` as before

Maybe this should be public available for all :)