### PR TITLE
Run composer:install as part of rollbacks.

### DIFF
--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -58,6 +58,7 @@ namespace :composer do
   end
 
   before 'deploy:updated', 'composer:install'
+  before 'deploy:reverted', 'composer:install'
 end
 
 namespace :load do


### PR DESCRIPTION
Situation:
1) App deploys normally, `composer:install` runs as part of deployment.
2) Run `cap deploy:rollback`
3) Composer-generated autoload files shared across releases now attempt to load release directory that no longer exists

Remedy:
Trigger `composer:install` during rollbacks as well as deploys.