### PR TITLE
use release_path method

### DIFF
--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -65,7 +65,7 @@ namespace :load do
   task :defaults do
     set :composer_install_flags, '--no-dev --prefer-dist --no-interaction --quiet --optimize-autoloader'
     set :composer_roles, :all
-    set :composer_working_dir, -> { fetch(:release_path) }
+    set :composer_working_dir, -> { release_path }
     set :composer_dump_autoload_flags, '--optimize'
     set :composer_download_url, "https://getcomposer.org/installer"
   end


### PR DESCRIPTION
fetch(:release_path) does not return anything when not creating a new
release, as is the case when running one-off commands.

the release_path method however, falls back to current_path, which is
always set
