### PR TITLE
add options for composer and php binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Capistrano's default deploy, or can be run in isolation with:
 $ cap production composer:install
 ```
 
-By default it is assumed that you have the composer executable installed and in your
+By default it is assumed that you have the Composer executable installed and in your
 `$PATH` on all target hosts.
 
 ### Configuration
@@ -54,33 +54,33 @@ set :composer_install_flags, '--no-dev --no-interaction --quiet --optimize-autol
 set :composer_roles, :all
 set :composer_working_dir, -> { fetch(:release_path) }
 set :composer_dump_autoload_flags, '--optimize'
-set :composer_download_url, "https://getcomposer.org/installer"
-set :composer_version, '1.0.0-alpha8' #(default: not set)
+set :composer_download_url, 'https://getcomposer.org/installer'
+set :composer_version, '1.0.0-alpha8' # (default: not set)
 set :composer_bin, 'bin/composer.phar' # (default: not set)
 set :composer_php, 'php5' # (default: not set)
 ```
 
-### Installing composer as part of a deployment
+### Installing Composer as part of a deployment
 
 To install Composer as part of the deployment, set `:composer_bin` to `:local`.
 This ensures installation of a local `composer.phar` in the shared path.
 
-### Accessing composer commands directly
+### Accessing Composer commands directly
 
 This library also provides a `composer:run` task which allows access to any
-composer command.
+Composer command.
 
 From the command line you can run
 
 ```bash
-$ cap production composer:run['status','--profile']
+$ cap production composer:run[status,--profile]
 ```
 
-Or from within a rake task using capistrano's `invoke`
+Or from within a rake task using Capistrano's `invoke`
 
 ```ruby
 task :my_custom_composer_task do
-  invoke "composer:run", :update, "--dev --prefer-dist"
+  invoke 'composer:run', :update, '--dev --prefer-dist'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,20 +56,14 @@ set :composer_working_dir, -> { fetch(:release_path) }
 set :composer_dump_autoload_flags, '--optimize'
 set :composer_download_url, "https://getcomposer.org/installer"
 set :composer_version, '1.0.0-alpha8' #(default: not set)
+set :composer_bin, 'bin/composer.phar' # (default: not set)
+set :composer_php, 'php5' # (default: not set)
 ```
 
 ### Installing composer as part of a deployment
 
-Add the following to `deploy.rb` to manage the installation of composer during
-deployment (composer.phar is install in the shared path).
-
-```ruby
-SSHKit.config.command_map[:composer] = "php #{shared_path.join("composer.phar")}"
-
-namespace :deploy do
-  after :starting, 'composer:install_executable'
-end
-```
+To install Composer as part of the deployment, set `:composer_bin` to `:local`.
+This ensures installation of a local `composer.phar` in the shared path.
 
 ### Accessing composer commands directly
 

--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -58,11 +58,11 @@ namespace :composer do
           set :composer_roles, :all
     DESC
   task :install do
-    invoke "composer:run", :install, fetch(:composer_install_flags)
+    invoke 'composer:run', :install, fetch(:composer_install_flags)
   end
 
   task :dump_autoload do
-    invoke "composer:run", :dumpautoload, fetch(:composer_dump_autoload_flags)
+    invoke 'composer:run', :dumpautoload, fetch(:composer_dump_autoload_flags)
   end
 
   desc <<-DESC
@@ -73,7 +73,7 @@ namespace :composer do
           set :composer_version, '1.0.0-alpha8'
     DESC
   task :self_update do
-    invoke "composer:run", :selfupdate, fetch(:composer_version, '')
+    invoke 'composer:run', :selfupdate, fetch(:composer_version, '')
   end
 
   before 'deploy:updated', 'composer:install'
@@ -93,6 +93,6 @@ namespace :load do
     set :composer_roles, :all
     set :composer_working_dir, -> { fetch(:release_path) }
     set :composer_dump_autoload_flags, '--optimize'
-    set :composer_download_url, "https://getcomposer.org/installer"
+    set :composer_download_url, 'https://getcomposer.org/installer'
   end
 end


### PR DESCRIPTION
Added `:composer_bin` and `:composer_php` options for better control of
which binaries to use.
When not explicitly set, the existence of the `composer` and `php`
executables is now validated before the tasks are run.

Also Composer is now always invoked through php. For this the path to
the `composer` executable is expanded by calling `which composer` on
the remote host.

When `:composer_bin` is set to `:local`, `composer:install_executable`
is automatically invoked on deployment. So no more manual hooking of
additional tasks in the deploy configuration.

This more or less supersedes #41, but I think this is more flexible.