### PR TITLE
Fix working dir bug when composer:run is executed directly via the CLI

### DIFF
--- a/lib/capistrano/tasks/composer.rake
+++ b/lib/capistrano/tasks/composer.rake
@@ -70,7 +70,7 @@ namespace :load do
   task :defaults do
     set :composer_install_flags, '--no-dev --prefer-dist --no-interaction --quiet --optimize-autoloader'
     set :composer_roles, :all
-    set :composer_working_dir, -> { release_path }
+    set :composer_working_dir, -> { release_path || current_path }
     set :composer_dump_autoload_flags, '--optimize'
     set :composer_download_url, "https://getcomposer.org/installer"
   end


### PR DESCRIPTION
When not running via a deploy (e.g. composer:run executed directly via CLI), the command fails because
the release_path variable is not set. It's only set as part of a deploy.

This fix changes the way composer:run works: when not executed within the context of a deploy, Composer's
working directory will be set to current_path instead of release_path.

This is a backwards-compatible bugfix, but it might be worth bumping at least minor version because
behavior changes considerably for end-users.